### PR TITLE
Update to use boto3 + python3 etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,15 @@
 FROM alpine:latest
 MAINTAINER Chris Barrett <chris@codesaru.com>
 
-RUN apk --update add py2-pip \
+RUN apk --update add py3-pip \
 	&& pip install awscli \
+        && pip install iplookup \
 	&& rm -rf /var/cache/apk/*
 
 RUN addgroup -S route53 \
     && adduser -G route53 -S -D route53
 USER route53:route53
 
-#COPY aws /root/.aws
 COPY main.py /
 
-#CMD ["/bin/sh"]  # for debugging
 CMD [ "python", "./main.py" ]
-#CMD cron && tail -f /var/log/cron.log
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ USER route53:route53
 
 COPY main.py /
 
-CMD [ "python3", "./main.py" ]
+ENTRYPOINT [ "/main.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ USER route53:route53
 
 COPY main.py /
 
-ENTRYPOINT [ "/main.py" ]
+CMD [ "/usr/bin/python3", "-u", "/main.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ USER route53:route53
 
 COPY main.py /
 
-CMD [ "python", "./main.py" ]
+CMD [ "python3", "./main.py" ]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,13 +1,12 @@
 # Route 53 updater for DDNS-like home network access.
-#
-FROM alpine:latest
-LABEL maintainer="Chris Barrett <chris@codesaru.com>"
+# This image is for 64bit ARMv8 systems
+FROM arm64v8/python:3.8-alpine
 
 COPY requirements.txt /
 RUN apk --update add py3-pip \
-	&& pip install --no-cache-dir -r requirements.txt \
+	&& python3 -m pip install -r requirements.txt \
 	&& rm -rf /var/cache/apk/* \
-    && rm -f /requirements.txt
+        && rm -f /requirements.txt
 
 RUN addgroup -S route53 \
     && adduser -G route53 -S -D route53
@@ -15,4 +14,4 @@ USER route53:route53
 
 COPY main.py /
 
-CMD [ "/usr/bin/python3", "-u", "/main.py" ]
+CMD [ "/usr/local/bin/python3", "-u", "/main.py" ]

--- a/main.py
+++ b/main.py
@@ -1,24 +1,30 @@
-#!/usr/bin/python
+#!/bin/env python3
 
 import os
 import time
-import urllib
+import requests
+import socket
+from datetime import datetime
 
 import botocore
 import botocore.session
 
+from iplookup import iplookup
+
 # required env vars
-HOSTED_ZONE_ID = os.getenv('R53_HOSTED_ZONE_ID', None)  # TODO get config'd zone ID string (such as for codesaru.com)
-DNS_NAME       = os.getenv('DNS_NAME', None)  # TODO get from config (such as 'home.codesaru.com')
+R53_HOSTED_ZONE_ID = os.getenv('R53_HOSTED_ZONE_ID', None)
+DNS_NAME = os.getenv('DNS_NAME', None)
 
 # optional env vars
 PUBLIC_IP_URL = os.getenv('PUBLIC_IP_URL', 'http://checkip.amazonaws.com')
-TTL_SECONDS   = int(os.getenv('TTL_SECONDS', '300'))
+TTL_SECONDS = int(os.getenv('TTL_SECONDS', '300'))
 RETRY_SECONDS = TTL_SECONDS // 2
 
 
-assert HOSTED_ZONE_ID, "Route53's Hosted Zone ID should be set to env var HOSTED_ZONE_ID."
-assert DNS_NAME, "The DNS name to update A records for should be set to env var DNS_NAME."
+if not R53_HOSTED_ZONE_ID:
+    logit("ERROR", "Route53's Hosted Zone ID should be set to env var R53_HOSTED_ZONE_ID.")
+if not DNS_NAME:
+    logit("ERROR", "The DNS name to update A records for should be set to env var DNS_NAME.")
 
 
 # it's expected that you've volume-mounted a file with only the creds this container should use
@@ -26,52 +32,69 @@ session = botocore.session.get_session()
 route53_client = session.create_client('route53')
 
 
-def update_ip():
-    # get WAN IP
-    while True:
-        try:
-            f = urllib.urlopen(PUBLIC_IP_URL)
-            break
-        except IOError as e:
-            if e.errno == -3:  # "Try again"
-                print('Got IOError -3: "Try again".  Retrying after a sleep...')
-                time.sleep(RETRY_SECONDS)
-            else:
-                raise
-    assert f.getcode() == 200, 'Failed to get public IP'
-    public_ip = f.read().strip()
-    #print 'Discovered public IP: ' + public_ip
+def getdate():
+    return datetime.now().strftime('%d/%m/%Y %H:%M:%S')
 
+
+def logit(level, message):
+    print(f'[{level.upper()}] {getdate()}: {message}')
+
+
+def is_valid_ipv4_address(address):
+    try:
+        socket.inet_pton(socket.AF_INET, address)
+    except AttributeError:  # no inet_pton here, sorry
+        try:
+            socket.inet_aton(address)
+        except socket.error:
+            return False
+        return address.count('.') == 3
+    except socket.error:  # not a valid address
+        return False
+
+    return True
+
+
+def update_ip():
+    # Get current DNS IP
+    ip = iplookup.iplookup
+    current_ip = ip(DNS_NAME)[0]
+    # get WAN IP
+    r = requests.get(PUBLIC_IP_URL)
+    public_ip = r.text.strip()
+    if not r.status_code == 200:
+        logit("WARN", f'Request to {PUBLIC_IP_URL} failed')
+    if not is_valid_ipv4_address(public_ip):
+        logit("WARN", f'Failed to receive valid IP: {public_ip}')
+
+    logit("INFO", f'Current DNS IP:\t{current_ip}')
+    logit("INFO", f'Current Public IP:\t{public_ip}')
+    # See if they're different
+    if public_ip == current_ip:
+        logit("INFO", f'No IP Change, skipping...')
+        return
+    logit("INFO", "Updating DNS...")
 
     # update Route 53
     response = route53_client.change_resource_record_sets(
-            HostedZoneId=HOSTED_ZONE_ID,
-            ChangeBatch={
-                'Comment': 'Update public IP address from Docker container.',
-                'Changes': [
-                    {
-                        'Action': 'UPSERT',
-                        'ResourceRecordSet': {
-                            'Name': str(DNS_NAME),
-                            'Type': 'A',
-                            'TTL': int(TTL_SECONDS),
-                            'ResourceRecords': [
-                                { 'Value': public_ip }
-                            ]
-                        }
-                    },
-                    {
-                        'Action': 'UPSERT',
-                        'ResourceRecordSet': {
-                            'Name': '*.' + str(DNS_NAME),
-                            'Type': 'A',
-                            'TTL': int(TTL_SECONDS),
-                            'ResourceRecords': [
-                                { 'Value': public_ip }
-                            ]
-                        }
+        HostedZoneId=R53_HOSTED_ZONE_ID,
+        ChangeBatch={
+            'Comment': 'Update public IP address from Docker container.',
+            'Changes': [
+                {
+                    'Action': 'UPSERT',
+                    'ResourceRecordSet': {
+                        'Name': str(DNS_NAME),
+                        'Type': 'A',
+                        'TTL': int(TTL_SECONDS),
+                        'ResourceRecords': [
+                            {'Value': public_ip}
+                        ]
                     }
-                ]})
+                }
+            ]
+        }
+    )
 
     print(response['ChangeInfo']['Status'])
 
@@ -82,4 +105,3 @@ if __name__ == '__main__':
     while os.getenv('KEEP_CONTAINER_ALIVE', 'False').lower() == 'true':
         time.sleep(int(TTL_SECONDS))
         update_ip()
-

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/python3
 
 from os import getenv
 from sys import exit

--- a/main.py
+++ b/main.py
@@ -1,117 +1,132 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
-from os import getenv
-from sys import exit
-import time
-import requests
+import logging
+import os
 import socket
+import time
 from datetime import datetime
+from sys import exit
 
-import botocore
-import botocore.session
-
+import boto3
+import requests
 from iplookup import iplookup
 
 
-def logit(level, message):
-    print(f'[{level.upper()}] {getdate()}: {message}')
+class Route53updater():
+    def __init__(self, hostedZoneId, dnsName, publicIpUrl, ttl=30):
+        """Class to check/update a Route53 A Record, based on an external IP lookup (eg. for Dynamic IPs on a home network)
 
+        Args:
+            hostedZoneId (string): AWS Route53 Hosted Zone ID
+            dnsName (string): Domain (FQDN) to maintain in Route53
+            publicIpUrl (string): Domain to use to check our current external IP
+            ttl (int): TTL value to apply to the DNS record.
+        """
+        # it's expected that you've volume-mounted a file with only the creds this container should use
+        self.route53_client = boto3.client('route53')
+        self.hostedZoneId = hostedZoneId
+        self.dnsName = dnsName
+        self.publicIpUrl = publicIpUrl
+        self.ttl = ttl
 
-def getdate():
-    return datetime.now().strftime('%d/%m/%Y %H:%M:%S')
-
-
-# required env vars
-R53_HOSTED_ZONE_ID = getenv('R53_HOSTED_ZONE_ID', None)
-DNS_NAME = getenv('DNS_NAME', None)
-
-# optional env vars
-PUBLIC_IP_URL = getenv('PUBLIC_IP_URL', 'http://checkip.amazonaws.com')
-TTL_SECONDS = int(getenv('TTL_SECONDS', '300'))
-RETRY_SECONDS = TTL_SECONDS // 2
-
-
-if not R53_HOSTED_ZONE_ID:
-    logit("ERROR", "Route53's Hosted Zone ID should be set to env var R53_HOSTED_ZONE_ID.")
-    exit(1)
-if not DNS_NAME:
-    logit("ERROR", "The DNS name to update A records for should be set to env var DNS_NAME.")
-    exit(1)
-
-
-# it's expected that you've volume-mounted a file with only the creds this container should use
-session = botocore.session.get_session()
-route53_client = session.create_client('route53')
-
-
-def is_valid_ipv4_address(address):
-    try:
-        socket.inet_pton(socket.AF_INET, address)
-    except AttributeError:  # no inet_pton here, sorry
+    def is_valid_ipv4_address(self, address):
         try:
-            socket.inet_aton(address)
-        except socket.error:
+            socket.inet_pton(socket.AF_INET, address)
+        except AttributeError:  # no inet_pton here, sorry
+            try:
+                socket.inet_aton(address)
+            except socket.error:
+                return False
+            return address.count('.') == 3
+        except socket.error:  # not a valid address
             return False
-        return address.count('.') == 3
-    except socket.error:  # not a valid address
-        return False
 
-    return True
+        return True
 
+    def update_ip(self):
+        try:
+            logging.info("IP Update Check Started")
+            # Get current DNS A record (IP)
+            ip = iplookup.iplookup
+            try:
+                current_ip = ip(self.dnsName)[0]
+            except IndexError as err:
+                logging.warning(f'Failed to lookup {self.dnsName} - assuming it doesn\'t exist yet, and continuing!')
+                current_ip = "1.2.3.4"
+            # get WAN IP
+            r = requests.get(self.publicIpUrl)
+            public_ip = r.text.strip()
+            if not r.status_code == 200:
+                logging.warning(f'Request to {self.publicIpUrl} failed')
+                return
+            if not self.is_valid_ipv4_address(public_ip):
+                logging.warning(f'Failed to receive valid IP: {public_ip}')
+                return
 
-def update_ip():
-    try:
-        logit("INFO", "IP Update Check Started")
-        # Get current DNS IP
-        ip = iplookup.iplookup
-        current_ip = ip(DNS_NAME)[0]
-        # get WAN IP
-        r = requests.get(PUBLIC_IP_URL)
-        public_ip = r.text.strip()
-        if not r.status_code == 200:
-            logit("WARN", f'Request to {PUBLIC_IP_URL} failed')
-            return
-        if not is_valid_ipv4_address(public_ip):
-            logit("WARN", f'Failed to receive valid IP: {public_ip}')
-            return
+            logging.info(f'Current DNS IP:\t{current_ip}')
+            logging.info(f'Current Public IP:\t{public_ip}')
+            # See if they're different
+            if public_ip == current_ip:
+                logging.info('No IP Change Required')
+                return
+            logging.warning("Updating DNS...")
 
-        logit("INFO", f'Current DNS IP:\t{current_ip}')
-        logit("INFO", f'Current Public IP:\t{public_ip}')
-        # See if they're different
-        if public_ip == current_ip:
-            logit("INFO", 'No IP Change Required')
-            return
-        logit("WARN", "Updating DNS...")
-
-        # update Route 53
-        response = route53_client.change_resource_record_sets(
-            HostedZoneId=R53_HOSTED_ZONE_ID,
-            ChangeBatch={
-                'Comment': 'Update public IP address from Docker container.',
-                'Changes': [
-                    {
-                        'Action': 'UPSERT',
-                        'ResourceRecordSet': {
-                            'Name': str(DNS_NAME),
-                            'Type': 'A',
-                            'TTL': int(TTL_SECONDS),
-                            'ResourceRecords': [
-                                {'Value': public_ip}
-                            ]
+            # update Route 53
+            response = self.route53_client.change_resource_record_sets(
+                HostedZoneId=self.hostedZoneId,
+                ChangeBatch={
+                    'Comment': 'Update public IP address from Docker container.',
+                    'Changes': [
+                        {
+                            'Action': 'UPSERT',
+                            'ResourceRecordSet': {
+                                'Name': str(self.dnsName),
+                                'Type': 'A',
+                                'TTL': int(self.ttl),
+                                'ResourceRecords': [
+                                    {'Value': public_ip}
+                                ]
+                            }
                         }
-                    }
-                ]
-            }
-        )
-        print(response['ChangeInfo']['Status'])
-    except Exception as err:
-        logit("ERROR", f'An error occured whilst running the UpdateIP method:\n{err}')
+                    ]
+                }
+            )
+        except Exception as err:
+            # Catch all, so the container continues running/retrying if a failure occurs
+            logging.error(f'An error occured whilst running the UpdateIP method:\n{err}')
 
 
 if __name__ == '__main__':
-    update_ip()
+    # Setup logging how we want it
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S')
 
-    while getenv('KEEP_CONTAINER_ALIVE', 'True').lower() == 'true':
-        logit("INFO", f'Sleeping for {TTL_SECONDS} seconds')
-        time.sleep(int(TTL_SECONDS))
-        update_ip()
+    # required env vars
+    try:
+        R53_HOSTED_ZONE_ID = os.environ['R53_HOSTED_ZONE_ID']
+        DNS_NAME = os.environ['DNS_NAME']
+    except KeyError as err:
+        logging.error(f"Missing required variable: {err.args[0]}")
+        exit(1)
+
+    # optional env vars
+    PUBLIC_IP_URL = os.getenv('PUBLIC_IP_URL', 'http://checkip.amazonaws.com')
+    TTL_SECONDS = int(os.getenv('TTL_SECONDS', '300'))
+
+    # Instantiate the class
+    r53 = Route53updater(
+        hostedZoneId=R53_HOSTED_ZONE_ID,
+        dnsName=DNS_NAME,
+        publicIpUrl=PUBLIC_IP_URL
+    )
+
+    # Run the updater (once)
+    r53.update_ip()
+
+    # If KEEP_CONTAINER_ALIVE, run periodically every TTL_SECONDS
+    while os.getenv('KEEP_CONTAINER_ALIVE', 'True').lower() == 'true':
+        logging.info(f'Sleeping for {TTL_SECONDS} seconds')
+        time.sleep(TTL_SECONDS)
+        r53.update_ip()

--- a/main.py
+++ b/main.py
@@ -60,6 +60,7 @@ def is_valid_ipv4_address(address):
 
 
 def update_ip():
+    logit("INFO", "IP Update Check Started")
     # Get current DNS IP
     ip = iplookup.iplookup
     current_ip = ip(DNS_NAME)[0]
@@ -77,9 +78,9 @@ def update_ip():
     logit("INFO", f'Current Public IP:\t{public_ip}')
     # See if they're different
     if public_ip == current_ip:
-        logit("INFO", f'No IP Change, skipping...')
+        logit("INFO", 'No IP Change Required')
         return
-    logit("INFO", "Updating DNS...")
+    logit("WARN", "Updating DNS...")
 
     # update Route 53
     response = route53_client.change_resource_record_sets(
@@ -108,6 +109,7 @@ def update_ip():
 if __name__ == '__main__':
     update_ip()
 
-    while getenv('KEEP_CONTAINER_ALIVE', 'False').lower() == 'true':
+    while getenv('KEEP_CONTAINER_ALIVE', 'True').lower() == 'true':
+        logit("INFO", f'Sleeping for {TTL_SECONDS} seconds')
         time.sleep(int(TTL_SECONDS))
         update_ip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+requests
+iplookup


### PR DESCRIPTION
Hey, firstly, thanks for making this 👍 

I made some tweaks (well... kinda refactored lol) locally for:
* Moving to object oriented model
* Update to boto3
* Update to python3 (3.8)
* Added an arm64v8 Dockerfile for those who want it (I've run this on Raspberry Pis/NVIDIA Jetson Nano for example)
* Adds comparison of the current record, vs the current WAN IP, so we only send an UPSERT if there is a change
* Separates the loop time (TTL_SECONDS) from the DNS record's TTL as typically you'll want a low record TTL so that changes take effect faster (5minutes is a bit slow for my tastes personally)
* Fix the MAINTAINER value in the Dockerfile to be a label, as MAINTAINER is deprecated now.

Up to you if you want to merge this :) the build is available here in case you want to check it out before merging etc: https://hub.docker.com/repository/docker/dalgibbard/route53-updater-docker

This gives some logging enhancements too, which play nicely with the UNRAID log views, with warns/errors etc being colourised :) example output format:
```
[INFO] 07/08/2020 10:16:36: IP Update Check Started
[INFO] 07/08/2020 10:16:37: Current DNS IP: 1.2.3.4
[INFO] 07/08/2020 10:16:37: Current Public IP: 1.2.3.4
[INFO] 07/08/2020 10:16:37: No IP Change Required
[INFO] 07/08/2020 10:16:37: Sleeping for 300 seconds
```